### PR TITLE
Feature/69 US06#Cadastro de Árbitro (formulário)

### DIFF
--- a/src/app/controllers/JudgeManagement.js
+++ b/src/app/controllers/JudgeManagement.js
@@ -1,6 +1,6 @@
-import Judge from "../models/Judge";
-import Database from "../../database";
-import PasswordGenerator from "password-generator";
+import Judge from '../models/Judge';
+import Database from '../../database';
+import PasswordGenerator from 'password-generator';
 
 module.exports = {
   async create(req, res) {
@@ -11,10 +11,13 @@ module.exports = {
       await Judge.create({ name, email, password: generatedPassword });
       return res.status(201).json({ password: generatedPassword });
     } catch (error) {
-      return res.status(401).send();
+      if (error.errors[0].validatorKey === 'not_unique') {
+        return res.status(409).send('Árbitro já cadastrado.');
+      }
+      return res.status(500).send('Não foi possível cadastrar o árbitro.');
     }
   },
   async update(req, res) {
     return res.json({ ok: true });
-  }
+  },
 };


### PR DESCRIPTION
## Tipo da mudança

- [ ] Resolver Bug
- [X] Adicionar nova funcionalidade
- [ ] Atualizar documentação

## Descrição das mudanças
O servidor agora apresenta um erro específico para árbitros já cadastrados, e retorna o erro 500 ao invés de 401 para erros no banco de dados durante o cadastro de árbitros.